### PR TITLE
Resampling: label = left

### DIFF
--- a/technical/util.py
+++ b/technical/util.py
@@ -62,7 +62,7 @@ def resample_to_interval(dataframe, interval):
     df = dataframe.copy()
     df = df.set_index(DatetimeIndex(df["date"]))
     ohlc_dict = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
-    df = df.resample(str(interval) + "min", label="right").agg(ohlc_dict).dropna()
+    df = df.resample(str(interval) + "min", label="left").agg(ohlc_dict).dropna()
     df["date"] = df.index
 
     return df


### PR DESCRIPTION
Hi!
This PR partially fix resampling logic.
Missing how to manage `resampled_merge` and how to align to `merge_informative_pair` behaviour (main repo).
Probably it will need a PR coordinated with the main repo.

Fixes freqtrade/technical#180